### PR TITLE
main_test: Avoid false negative due map ordering

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -431,6 +431,15 @@ func TestMergeFuncsByFiles(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			merge := mergeFuncsByFiles(tc.in.a, tc.in.b)
+
+			sort.Slice(merge, func(i, j int) bool {
+				return merge[i].Filename < merge[j].Filename
+			})
+
+			sort.Slice(tc.expected, func(i, j int) bool {
+				return tc.expected[i].Filename < tc.expected[j].Filename
+			})
+
 			require.Len(t, merge, len(tc.expected))
 			require.Equal(t, tc.expected, merge)
 		})


### PR DESCRIPTION
The test for mergeFuncsByFiles function could return false negatives due
the non-deterministic order of its results; for avoiding them the
results of it and the expected results must be sorted before comparing
them.